### PR TITLE
新增value字段用于初始值 onOk函数用于确定后不关闭prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ ReactDOM.render(<App />, document.getElementById('root'));
 
 ## Keep modal open after submit
 
-[![Edit antd-prompt](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/antd-prompt-fohcs?fontsize=14)
 
 ```js
 import React, { component } from 'react';

--- a/README.md
+++ b/README.md
@@ -50,3 +50,38 @@ class App extends Component {
 
 ReactDOM.render(<App />, document.getElementById('root'));
 ```
+
+## Keep modal open after submit
+
+[![Edit antd-prompt](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/antd-prompt-fohcs?fontsize=14)
+
+```js
+import React, { component } from 'react';
+import ReactDOM from 'react-dom';
+import prompt from 'antd-prompt';
+import { Button, message } from 'antd';
+
+class App extends Component {
+    handler = async () => {
+        await prompt({
+            title: "Please enter name",
+            value: 'Initial Value',
+            modalProps: {
+                width: '80%'
+            },
+            onOk: name => {
+                // do something with name
+                return false;
+            }
+        });
+    }
+    render() {
+        return <div>
+            <Button onClick={this.handler}>Set Name</Button>
+        </div>
+    }
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ class App extends Component {
             onOk: name => {
                 // do something with name
                 return false;
+                // or return Promise.resolve(false);
             }
         });
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { Modal, Input, Form } from 'antd';
 import { Rule } from 'antd/es/form';
@@ -8,18 +8,21 @@ interface Props {
   rules?: Rule[];
   placeholder?: string;
   ref?: any;
+  value?: string;
   onPressEnter?: () => void;
 }
 
 const PromptForm = forwardRef(
-  ({ rules, placeholder, onPressEnter }: Props, ref: any) => {
+  ({ rules, placeholder, onPressEnter, value }: Props, ref: any) => {
     const [formInstance] = Form.useForm();
+
+    useEffect(() => {
+      formInstance.setFieldsValue({ input: value });
+    }, []);
 
     useImperativeHandle(ref, () => ({
       validate: () => {
-        return formInstance.validateFields().then((res) => {
-          return Promise.resolve(res.input);
-        });
+        return formInstance.validateFields().then((res) => res.input);
       },
     }));
 
@@ -35,6 +38,7 @@ const PromptForm = forwardRef(
 
 interface PromptConfig {
   title: string;
+  value?: string;
   rules?: Rule[];
   placeholder?: string;
   modalProps?: Partial<ModalProps>;
@@ -58,6 +62,7 @@ function Prompt({
   submit,
   close,
   title,
+  value,
   afterClose,
 }: PromptProps) {
   const formRef = useRef<any>(null);
@@ -82,6 +87,7 @@ function Prompt({
       <PromptForm
         ref={formRef}
         rules={rules}
+        value={value}
         placeholder={placeholder}
         onPressEnter={handleOk}
       />


### PR DESCRIPTION
新增value字段，可以渲染初始值

新增onOk函数，返回true或者false或者不返回。如果返回false，则不关闭prompt。
onOk也可为异步函数。

原先使用方式不变

使用方式：
```
prompt({
            title: '修改名称',
            value: '初始值‘,
            modalProps: {
                okText: '确认',
                cancelText: '取消',
            },
            rules: [{ required: true, message: '名称不可为空' }],
            onOk: res => {
                console.log(res);
                return false;
            }
        });
```
