### PR TITLE
:bug: new autoFocus props should be typescript exposed

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,7 @@ interface PromptConfig {
   placeholder?: string;
   modalProps?: Partial<ModalProps>;
   onOk?: (value?: string) => boolean | Promise<boolean>;
+  autoFocus?: boolean;
 }
 
 interface PromptProps extends Props {


### PR DESCRIPTION
Hi,

this PR is a follow-up of https://github.com/wangsijie/antd-prompt/pull/24.
I realized that the main typescript definition has not been updated, which causes an issue when using the new flag in typescript. This is not the case in the example directory with is in JS.

Sorry about this.

